### PR TITLE
Omit progress bar from SPProcessor when using load_leaner()

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -459,8 +459,11 @@ class SPProcessor(PreProcessor):
 
     def process(self, ds):
         ds.items = _join_texts(ds.items, self.mark_fields, self.include_bos, self.include_eos)
-        ds.items = [apply_rules(t, pre_rules=self.pre_rules, post_rules=self.post_rules) 
-                    for t in progress_bar(ds.items, leave=False)]
+        if len (ds.items) > 0: ds.items = [apply_rules(t, pre_rules=self.pre_rules, post_rules=self.post_rules) 
+                                           for t in progress_bar(ds.items, leave=False)]
+        else: ds.items =  [apply_rules(t, pre_rules=self.pre_rules, post_rules=self.post_rules) 
+                           for t in ds.items]
+        
         if self.sp_model is None or self.sp_vocab is None:
             cache_dir = self.train_func(ds.items, ds.path)
             self.sp_model,self.sp_vocab = cache_dir/'spm.model',cache_dir/'spm.vocab'


### PR DESCRIPTION
Disclaimer: sorry if I miss any rules. This is my first PR and I am a law professor, not a programmer.

**The problem**:
1 - Export a language classifier that uses sentencepiece tokenizer (ie.: MultiFit) using learn.export()
2 - Load it using load_learner(). There won't be any ds.items.
3 - Run this directly from the terminal

This situation triggers a "division by zero" error due to progress_bar() receiving len(ds.items) == 0. This error only happens when executing the .py file directly from the command line. There's no error when running inside notebooks.

To fix this, I've omitted the progress bar when len(ds.items) is 0. I believe it would be better to fix the fastprogress, but I am not confident I could change it without making a mess.
This solved my problem. I hope it helps.

**Traceback:**

```

/usr/local/lib/python3.7/site-packages/fastprogress/fastprogress.py:102: UserWarning: Your generator is empty.
  warn("Your generator is empty.")
Traceback (most recent call last):
  File "bugfastai.py", line 27, in <module>
    learn_c = load_learner(home, 'classificador_lai_sp15_multifit_fwd_export')
  File "/usr/local/lib/python3.7/site-packages/fastai/basic_train.py", line 616, in load_learner
    src = LabelLists.load_state(path, state.pop('data'))
  File "/usr/local/lib/python3.7/site-packages/fastai/data_block.py", line 578, in load_state
    train_ds = LabelList.load_state(path, state)
  File "/usr/local/lib/python3.7/site-packages/fastai/data_block.py", line 692, in load_state
    res = cls(x, y, tfms=state['tfms'], tfm_y=state['tfm_y'], **state['tfmargs']).process()
  File "/usr/local/lib/python3.7/site-packages/fastai/data_block.py", line 714, in process
    self.x.process(xp)
  File "/usr/local/lib/python3.7/site-packages/fastai/data_block.py", line 84, in process
    for p in self.processor: p.process(self)
  File "/usr/local/lib/python3.7/site-packages/fastai/text/data.py", line 464, in process
    ds.items = [apply_rules(t, pre_rules=self.pre_rules, post_rules=self.post_rules) for t in progress_bar(ds.items, leave=False)]
  File "/usr/local/lib/python3.7/site-packages/fastai/text/data.py", line 464, in <listcomp>
    ds.items = [apply_rules(t, pre_rules=self.pre_rules, post_rules=self.post_rules) for t in progress_bar(ds.items, leave=False)]
  File "/usr/local/lib/python3.7/site-packages/fastprogress/fastprogress.py", line 70, in __iter__
    self.update(0)
  File "/usr/local/lib/python3.7/site-packages/fastprogress/fastprogress.py", line 85, in update
    self.update_bar(0)
  File "/usr/local/lib/python3.7/site-packages/fastprogress/fastprogress.py", line 103, in update_bar
    self.on_update(0, '100% [0/0]')
  File "/usr/local/lib/python3.7/site-packages/fastprogress/fastprogress.py", line 270, in on_update
    filled_len = int(self.length * val // self.total)
ZeroDivisionError: integer division or modulo by zero

```

**INSTALL INFO:**

```

=== Software === 
python       : 3.7.4
fastai       : 1.0.59
fastprogress : 0.1.21
torch        : 1.2.0
torch cuda   : None / is **Not available** 

=== Hardware === 
No GPUs available 

=== Environment === 
platform     : Darwin-17.7.0-x86_64-i386-64bit
conda env    : Unknown
python       : /usr/local/opt/python/bin/python3.7
sys.path     : /Users/usuario/Dropbox/UFRN/Ouvidoria/Python
/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python37.zip
/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7
/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/lib-dynload
/usr/local/lib/python3.7/site-packages
/usr/local/lib/python3.7/site-packages/IPython/extensions
no supported gpus found on this system

```

